### PR TITLE
Set parallelism to 5

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -5,4 +5,4 @@ type: application
 
 version: 1.0.2
 
-appVersion: 130
+appVersion: "130"

--- a/templates/tonic-web-server-deployment.yaml
+++ b/templates/tonic-web-server-deployment.yaml
@@ -78,6 +78,8 @@ spec:
           value: {{quote .Values.tonicSsoConfig.groupFilter }}
           {{- end }}
           {{- end }}
+        - name: TONIC_SPARK_URL
+          value: https://tonic-spark-helper:5501
         image: quay.io/tonicai/tonic_web_server:{{ .Values.tonicVersion }}
         imagePullPolicy: ""
         name: tonic-web-server

--- a/templates/tonic-worker-deployment.yaml
+++ b/templates/tonic-worker-deployment.yaml
@@ -34,11 +34,11 @@ spec:
         - name: TONIC_DB_HOST
           value: {{ .Values.tonicdb.host }}
         - name: TONIC_PROCESS_PARALLELISM
-          value: "1"
+          value: "5"
         - name: TONIC_TABLE_PARALLELISM
-          value: "1"
+          value: "5"
         - name: TONIC_WRITE_PARALLELISM
-          value: "1"
+          value: "5"
           {{- if .Values.tonicStatisticsSeed }}
         - name: TONIC_STATISTICS_SEED
           value: {{quote .Values.tonicStatisticsSeed }}


### PR DESCRIPTION
### Summary
Increase parallelism for tonic worker from 1 to 5 in the `tonic-worker-deployment.yaml` file

### Context
<img width="406" alt="Screen Shot 2021-05-18 at 4 47 02 PM" src="https://user-images.githubusercontent.com/57813967/118721310-ad2b4a80-b7f8-11eb-9e74-f1373b7474ee.png">
