### PR TITLE
B/image pull policy

### DIFF
--- a/templates/tonic-notifications-deployment.yaml
+++ b/templates/tonic-notifications-deployment.yaml
@@ -71,7 +71,7 @@ spec:
         - name: TONIC_NOTIFICATIONS_HEALTH_PORT_HTTPS
           value: "7001"
         image: quay.io/tonicai/tonic_notifications:{{ .Values.tonicVersion }}
-        imagePullPolicy: "Always"
+        imagePullPolicy: Always
         name: tonic-notifications
         ports:
         - containerPort: 7000

--- a/templates/tonic-notifications-deployment.yaml
+++ b/templates/tonic-notifications-deployment.yaml
@@ -71,7 +71,7 @@ spec:
         - name: TONIC_NOTIFICATIONS_HEALTH_PORT_HTTPS
           value: "7001"
         image: quay.io/tonicai/tonic_notifications:{{ .Values.tonicVersion }}
-        imagePullPolicy: ""
+        imagePullPolicy: "Always"
         name: tonic-notifications
         ports:
         - containerPort: 7000

--- a/templates/tonic-pii-detection-deployment.yaml
+++ b/templates/tonic-pii-detection-deployment.yaml
@@ -23,7 +23,7 @@ spec:
         - name: ENVIRONMENT_NAME
           value: {{ .Values.environmentName }}
         image: quay.io/tonicai/tonic_pii_detection:{{ .Values.tonicVersion }}
-        imagePullPolicy: "Always"
+        imagePullPolicy: Always
         name: tonic-pii-detection
         ports:
         - containerPort: 7687

--- a/templates/tonic-pii-detection-deployment.yaml
+++ b/templates/tonic-pii-detection-deployment.yaml
@@ -23,7 +23,7 @@ spec:
         - name: ENVIRONMENT_NAME
           value: {{ .Values.environmentName }}
         image: quay.io/tonicai/tonic_pii_detection:{{ .Values.tonicVersion }}
-        imagePullPolicy: ""
+        imagePullPolicy: "Always"
         name: tonic-pii-detection
         ports:
         - containerPort: 7687

--- a/templates/tonic-spark-helper-deployment.yaml
+++ b/templates/tonic-spark-helper-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         - name: ENVIRONMENT_NAME
           value: {{ .Values.environmentName }}
         image: quay.io/tonicai/tonic_spark_helper:{{ .Values.tonicVersion }}
-        imagePullPolicy: "Always"
+        imagePullPolicy: Always
         name: tonic-spark-helper
         ports:
         - containerPort: 5501

--- a/templates/tonic-spark-helper-deployment.yaml
+++ b/templates/tonic-spark-helper-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         - name: ENVIRONMENT_NAME
           value: {{ .Values.environmentName }}
         image: quay.io/tonicai/tonic_spark_helper:{{ .Values.tonicVersion }}
-        imagePullPolicy: ""
+        imagePullPolicy: "Always"
         name: tonic-spark-helper
         ports:
         - containerPort: 5501

--- a/templates/tonic-web-server-deployment.yaml
+++ b/templates/tonic-web-server-deployment.yaml
@@ -83,7 +83,7 @@ spec:
         - name: TONIC_NOTIFICATIONS_URL
           value: http://tonic-notifications:7000
         image: quay.io/tonicai/tonic_web_server:{{ .Values.tonicVersion }}
-        imagePullPolicy: ""
+        imagePullPolicy: "Always"
         name: tonic-web-server
         ports:
         - containerPort: 80

--- a/templates/tonic-web-server-deployment.yaml
+++ b/templates/tonic-web-server-deployment.yaml
@@ -83,7 +83,7 @@ spec:
         - name: TONIC_NOTIFICATIONS_URL
           value: http://tonic-notifications:7000
         image: quay.io/tonicai/tonic_web_server:{{ .Values.tonicVersion }}
-        imagePullPolicy: "Always"
+        imagePullPolicy: Always
         name: tonic-web-server
         ports:
         - containerPort: 80

--- a/templates/tonic-worker-deployment.yaml
+++ b/templates/tonic-worker-deployment.yaml
@@ -54,7 +54,7 @@ spec:
         - name: TONIC_NOTIFICATIONS_URL
           value: http://tonic-notifications:7000
         image: quay.io/tonicai/tonic_worker:{{ .Values.tonicVersion }}
-        imagePullPolicy: "Always"
+        imagePullPolicy: Always
         name: tonic-worker
         ports:
         - containerPort: 80

--- a/templates/tonic-worker-deployment.yaml
+++ b/templates/tonic-worker-deployment.yaml
@@ -54,7 +54,7 @@ spec:
         - name: TONIC_NOTIFICATIONS_URL
           value: http://tonic-notifications:7000
         image: quay.io/tonicai/tonic_worker:{{ .Values.tonicVersion }}
-        imagePullPolicy: ""
+        imagePullPolicy: "Always"
         name: tonic-worker
         ports:
         - containerPort: 80


### PR DESCRIPTION
When a customer uses the latest tag and does a helm upgrade, new images are not pulled unless this policy is either not set or set to always.

The policy does not change if it is just removed for existing installs so I set it explicitly.