### PR TITLE
Don't override system defaults for parallelism

### DIFF
--- a/templates/tonic-worker-deployment.yaml
+++ b/templates/tonic-worker-deployment.yaml
@@ -33,12 +33,12 @@ spec:
           value: {{ .Values.tonicdb.sslMode }}
         - name: TONIC_DB_HOST
           value: {{ .Values.tonicdb.host }}
-        - name: TONIC_PROCESS_PARALLELISM
-          value: "1"
-        - name: TONIC_TABLE_PARALLELISM
-          value: "1"
-        - name: TONIC_WRITE_PARALLELISM
-          value: "1"
+#        - name: TONIC_PROCESS_PARALLELISM
+#          value: "1"
+#        - name: TONIC_TABLE_PARALLELISM
+#          value: "1"
+#        - name: TONIC_WRITE_PARALLELISM
+#          value: "2"
           {{- if .Values.tonicStatisticsSeed }}
         - name: TONIC_STATISTICS_SEED
           value: {{quote .Values.tonicStatisticsSeed }}


### PR DESCRIPTION
Comment out the parallelism settings to use the system defaults (but leaving in place as commented for reference).