### PR TITLE
Adds TONIC_WEB_URL to worker deployment

### DIFF
--- a/templates/tonic-worker-deployment.yaml
+++ b/templates/tonic-worker-deployment.yaml
@@ -55,6 +55,8 @@ spec:
           value: https://tonic-notifications:7001
         - name: TONIC_PYML_URL
           value: https://tonic-pyml-service:7700
+        - name: TONIC_WEB_URL
+          value: https://tonic-web-server
           {{- if .Values.tonicai }}
           {{- if .Values.tonicai.oracle_helper }}
         - name: TONIC_ORACLE_HELPER_URL


### PR DESCRIPTION
This doesn't need to be handled the same as the SMTP configuration as it is purely an internal communication