### PR TITLE
TN-1698: Allow configuring non-privileged ports for web+worker

### DIFF
--- a/templates/tonic-web-server-deployment.yaml
+++ b/templates/tonic-web-server-deployment.yaml
@@ -8,6 +8,10 @@
   {{ $image = "quay.io/tonicai/tonic_web_server" }}
   {{- end }}
 {{- end }}
+{{- $ports := .Values.tonicai.web_server.ports }}
+{{- $httpsOnly := $ports.httpsOnly | default false }}
+{{- $httpPort := $ports.http | default 80 }}
+{{- $httpsPort := $ports.https | default 443 }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -128,12 +132,24 @@ spec:
           value: http://tonic-notifications:7000
         - name: TONIC_PYML_URL
           value: https://tonic-pyml-service:7700
+        {{- if not $httpsOnly }}
+        - name: TONIC_PORT_HTTP
+          value: {{ $httpPort | quote }}
+        {{- end }}
+        - name: TONIC_PORT_HTTPS
+          value: {{ $httpsPort | quote }}
+        - name: TONIC_HTTPS_ONLY
+          value: {{ $httpsOnly | quote }}
         image: {{ $image }}:{{ .Values.tonicVersion }}
         imagePullPolicy: Always
         name: tonic-web-server
         ports:
-        - containerPort: 80
-        - containerPort: 443
+        {{- if not $httpsOnly }}
+        - containerPort: {{ $httpPort }}
+          name: "http"
+        {{- end }}
+        - containerPort: {{ $httpsPort }}
+          name: "https"
         resources:
           limits:
             memory: "3Gi"

--- a/templates/tonic-web-server-service.yaml
+++ b/templates/tonic-web-server-service.yaml
@@ -20,7 +20,7 @@ spec:
   ports:
   - name: "https"
     port: 443
-    targetPort: 443
+    targetPort: "https"
 # use_ingress currently only used by TIM
 {{- if eq (.Values.tonicai).use_ingress true }}
   type: ClusterIP

--- a/templates/tonic-worker-deployment.yaml
+++ b/templates/tonic-worker-deployment.yaml
@@ -8,6 +8,10 @@
   {{- $image = "quay.io/tonicai/tonic_worker" }}
   {{- end }}
 {{- end }}
+{{- $ports := .Values.tonicai.worker.ports }}
+{{- $httpsOnly := $ports.httpsOnly | default false }}
+{{- $httpPort := $ports.http | default 80 }}
+{{- $httpsPort := $ports.https | default 443 }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -67,6 +71,14 @@ spec:
           value: https://tonic-pyml-service:7700
         - name: TONIC_WEB_URL
           value: https://tonic-web-server
+        - name: TONIC_HTTPS_ONLY
+          value: {{ $httpsOnly | quote }}
+        {{- if not $httpsOnly }}
+        - name: TONIC_WORKER_HEALTH_PORT_HTTP
+          value: {{ $httpPort | quote }}
+        {{- end }}
+        - name: TONIC_WORKER_HEALTH_PORT_HTTPS
+          value: {{ $httpsPort | quote }}
           {{- if .Values.tonicai }}
           {{- if .Values.tonicai.oracle_helper }}
         - name: TONIC_ORACLE_HELPER_URL
@@ -96,8 +108,12 @@ spec:
         imagePullPolicy: Always
         name: tonic-worker
         ports:
-        - containerPort: 80
-        - containerPort: 443
+        {{- if not $httpsOnly }}
+        - containerPort: {{ $httpPort }}
+          name: "http"
+        {{- end }}
+        - containerPort: {{ $httpsPort }}
+          name: "https"
         resources:
           limits:
             memory: "12Gi"

--- a/templates/tonic-worker-service.yaml
+++ b/templates/tonic-worker-service.yaml
@@ -1,3 +1,5 @@
+{{- $workerPorts := .Values.tonicai.worker.workerPorts | default dict }}
+{{- $httpsOnly := $workerPorts.httpsOnly | default false }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -7,12 +9,14 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   ports:
+  {{- if not $httpsOnly }}
   - name: "8080"
     port: 8080
-    targetPort: 80
+    targetPort: "http"
+  {{- end }}
   - name: "4433"
     port: 4433
-    targetPort: 443
+    targetPort: "https"
   selector:
     app: tonic-worker
 status:

--- a/values.sample.yaml
+++ b/values.sample.yaml
@@ -49,10 +49,18 @@ tonicai:
       # Enables/Disables the HostIntegrations endpoint
       host_integration_enabled: "true" 
       kubernetes_role: "default"
+    ports:
+      httpsOnly: true
+      https: 443
+      http: 80
   worker:
     image: quay.io/tonicai/tonic_worker
     env: {}
     envRaw: {}
+    ports:
+      httpsOnly: true
+      https: 443
+      http: 80
   notifications:
     image: quay.io/tonicai/tonic_notifications
   pii_detection:
@@ -64,7 +72,7 @@ tonicai:
 #   image: quay.io/tonicai/tonic_oracle_helper
 #   version: "19"
 #   lang: "AMERICAN_AMERICA.AL32UTF8"
-
+#
 # Enterprise License Only: Below are the settings for Single Sign On. Not every provider requires every value. The Tonic support team will help you configure this.
 # tonicSsoConfig:
 #   groupFilter: <regex that matches groups to import into Tonic, like .*Tonic.*>


### PR DESCRIPTION
The ticket mentions additionally adjusting notifications, but this chart already overrides the ports to be in the 7000 range.