### PR TITLE
Update for setting Tonic license

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Before deploying this setup, rename [values.sample.yaml](values.sample.yaml) to 
 
 ### Tonic license
 
-- `tonicLicense`: This value will be provided by Tonic.
+- This value will be provided by Tonic and must be input upon first startup of Tonic. Subsequently, it can be updated [from within the Tonic Admin portal](https://docs.tonic.ai/app/admin/on-premise-deployment/license-key-enter-update). Note that this was previously maintained via `tonicLicense`, but this is no longer needed since version 519.
 
 ### Environment name
 

--- a/values.sample.yaml
+++ b/values.sample.yaml
@@ -1,6 +1,3 @@
-# Use a Tonic license to enable different features. Your license key will be provided by Tonic.
-tonicLicense: <license-key>
-
 environmentName: <company-name>
 
 # tonicdb is the postgres database that will hold information about your workspace.
@@ -118,3 +115,6 @@ tonicai:
 
 # Role used by Tonic to connect to AWS Lambda. This is needed for Snowflake and Redshift integrations.
 # awsLambdaRoleArn: arn:aws:iam::<accountId>:role/<role-name>
+
+# Your license should be configured by an admin within the Tonic UI. It can optionally be set here if there is no admin.
+# tonicLicense: <license-key>


### PR DESCRIPTION
Removes TONIC_LICENSE. Since Tonic version 519, this is now maintained [directly within Tonic](https://docs.tonic.ai/app/admin/on-premise-deployment/license-key-enter-update).