### PR TITLE
Allow pulling from unprivileged sources

### DIFF
--- a/templates/tonic-notifications-deployment.yaml
+++ b/templates/tonic-notifications-deployment.yaml
@@ -1,3 +1,13 @@
+{{ $image := "" }}
+{{- if  ((.Values.tonicai).notifications).image }}
+{{- $image = .Values.tonicai.notifications.image
+{{- else }}
+  {{- if .Values.useUnprivilegedContainers
+  {{- $image = "quay.io/tonicai/tonic_notifications_unprivileged" }}
+  {{- else }}
+  {{- $image = "quay.io/tonicai/tonic_notifications" }}
+  {{- end }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -70,11 +80,7 @@ spec:
           value: "7000"
         - name: TONIC_NOTIFICATIONS_HEALTH_PORT_HTTPS
           value: "7001"
-        {{- if  ((.Values.tonicai).notifications).image }}
-        image: {{ .Values.tonicai.notifications.image }}:{{ .Values.tonicVersion }}
-        {{ else }}
-        image: quay.io/tonicai/tonic_notifications:{{ .Values.tonicVersion }}
-        {{- end }}
+        image: {{ $image }}
         imagePullPolicy: Always
         name: tonic-notifications
         resources:

--- a/templates/tonic-oracle-helper-deployment.yaml
+++ b/templates/tonic-oracle-helper-deployment.yaml
@@ -1,6 +1,16 @@
 {{- if .Values.tonicai }}
 {{- if .Values.tonicai.oracle_helper }}
+{{ $image := "" }}
 {{- if .Values.tonicai.oracle_helper.version }}
+{{- if ((.Values.tonicai).oracle_helper).image }}
+{{- $image = .Values.tonicai.oracle_helper.image }}
+{{- else }}
+  {{- if .Values.useUnprivilegedContainers }}
+  {{ $image = "quay.io/tonicai/tonic_oracle_helper_{{ .Values.tonicai.oracle_helper.version }}_unprivileged" }}
+  {{- else }}
+    {{ $image = "quay.io/tonicai/tonic_oracle_helper_{{ .Values.tonicai.oracle_helper.version }}" }}
+  {{- end }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -28,11 +38,7 @@ spec:
         - name: NLS_LANG
           value: {{ .Values.tonicai.oracle_helper.lang }}
         {{- end }}
-        {{- if  ((.Values.tonicai).oracle_helper).image }}
-        image: {{ .Values.tonicai.oracle_helper.image }}_{{ .Values.tonicai.oracle_helper.version }}:{{ .Values.tonicVersion }}
-        {{ else }}
-        image: quay.io/tonicai/tonic_oracle_helper_{{ .Values.tonicai.oracle_helper.version }}:{{ .Values.tonicVersion }}
-        {{- end }}
+        image: {{ $image }}:{{ .Values.tonicVersion }}
         imagePullPolicy: Always
         name: tonic-oracle-helper
         ports:

--- a/templates/tonic-pii-detection-deployment.yaml
+++ b/templates/tonic-pii-detection-deployment.yaml
@@ -1,3 +1,13 @@
+{{ $image := "" }}
+{{- if  ((.Values.tonicai).pii_detection).image }}
+{{ $image = .Values.tonicai.pii_detection.image }}
+{{ else }}
+  {{- if .Values.useUnprivilegedContainers }}
+  {{ $image = "quay.io/tonicai/tonic_pii_detection_unprivileged" }}
+  {{- else }}
+  {{ $image = "quay.io/tonicai/tonic_pii_detection" }}
+  {{- end}}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -22,11 +32,7 @@ spec:
           value: {{quote .Values.enableLogCollection }}
         - name: ENVIRONMENT_NAME
           value: {{ .Values.environmentName }}
-        {{- if  ((.Values.tonicai).pii_detection).image }}
-        image: {{ .Values.tonicai.pii_detection.image }}:{{ .Values.tonicVersion }}
-        {{ else }}
-        image: quay.io/tonicai/tonic_pii_detection:{{ .Values.tonicVersion }}
-        {{- end }}
+        image: {{ $image }}
         imagePullPolicy: Always
         name: tonic-pii-detection
         ports:

--- a/templates/tonic-pyml-deployment.yaml
+++ b/templates/tonic-pyml-deployment.yaml
@@ -1,3 +1,13 @@
+{{ $image := "" }}
+{{- if ((.Values.tonicai).pyml_service).image }}
+{{- $image = .Values.tonicai.pyml_service.image }}
+{{- else }}
+  {{- if .Values.useUnprivilegedContainers }}
+  {{- $image = "quay.io/tonicai/tonic_pyml_service_unprivileged" }}
+  {{- else }}
+  {{- $image = "quay.io/tonicai/tonic_pyml_service" }}
+  {{- end }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -22,11 +32,7 @@ spec:
           value: {{quote .Values.enableLogCollection }}
         - name: ENVIRONMENT_NAME
           value: {{ .Values.environmentName }}
-        {{- if  ((.Values.tonicai).pyml_service).image }}
-        image: {{ .Values.tonicai.pyml_service.image }}:{{ .Values.tonicVersion }}
-        {{ else }}
-        image: quay.io/tonicai/tonic_pyml_service:{{ .Values.tonicVersion }}
-        {{- end }}
+        image: {{ $image }}:{{ .Values.tonicVersion }}
         imagePullPolicy: Always
         name: tonic-pyml-service
         ports:

--- a/templates/tonic-web-server-deployment.yaml
+++ b/templates/tonic-web-server-deployment.yaml
@@ -1,3 +1,13 @@
+{{ $image := "" }}
+{{- if  ((.Values.tonicai).web_server).image }}
+{{ $image = .Values.tonicai.web_server.image }}
+{{ else }}
+  {{- if .Values.useUnprivilegedContainers }}
+  {{ $image = "quay.io/tonicai/tonic_web_server_unprivileged" }}
+  {{- else }}
+  {{ $image = "quay.io/tonicai/tonic_web_server" }}
+  {{- end }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -118,11 +128,7 @@ spec:
           value: http://tonic-notifications:7000
         - name: TONIC_PYML_URL
           value: https://tonic-pyml-service:7700
-        {{- if  ((.Values.tonicai).web_server).image }}
-        image: {{ .Values.tonicai.web_server.image }}:{{ .Values.tonicVersion }}
-        {{ else }}
-        image: quay.io/tonicai/tonic_web_server:{{ .Values.tonicVersion }}
-        {{- end }}
+        image: {{ $image }}
         imagePullPolicy: Always
         name: tonic-web-server
         ports:

--- a/templates/tonic-worker-deployment.yaml
+++ b/templates/tonic-worker-deployment.yaml
@@ -1,3 +1,13 @@
+{{ $image := "" }}
+{{- if  ((.Values.tonicai).worker).image }}
+{{- $image = .Values.tonicai.worker.image }}
+{{- else }}
+  {{- if .Values.useUnprivilegedContainers }}
+  {{ $image = "quay.io/tonicai/tonic_worker_unprivileged" }}
+  {{- else }}
+  {{- $image = "quay.io/tonicai/tonic_worker" }}
+  {{- end }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -82,11 +92,7 @@ spec:
         {{- end }}
         {{- end }}
         {{- end }}
-        {{- if  ((.Values.tonicai).worker).image }}
-        image: {{ .Values.tonicai.worker.image }}:{{ .Values.tonicVersion }}
-        {{ else }}
-        image: quay.io/tonicai/tonic_worker:{{ .Values.tonicVersion }}
-        {{- end }}
+        image: {{ $image }}
         imagePullPolicy: Always
         name: tonic-worker
         ports:

--- a/values.sample.yaml
+++ b/values.sample.yaml
@@ -1,4 +1,7 @@
 environmentName: <company-name>
+# use unprivileged containers only interacts with tonic provided images
+# it does not interact with customer provided image repositories
+useUnprivilegedContainers: false
 
 # tonicdb is the postgres database that will hold information about your workspace.
 tonicdb:


### PR DESCRIPTION
Adds a boolean flag to set pulling from unprivileged image repositories instead of the usual privileged ones. The default is to _not_ use unprivileged containers