### PR TITLE
fix: add quote to seed values

### DIFF
--- a/values.sample.yaml
+++ b/values.sample.yaml
@@ -36,7 +36,8 @@ tonicdb:
 
 # tonicStatisticsSeed will cause generations to be consisent with each other for anything where consistency is set to true.
 # otherwise each generation will be internally consistent, but not consistent with other generations.
-tonicStatisticsSeed: <any-integer>
+# add quote to integer values to get rid of helm cast large number to float64, refer to this issue: https://github.com/helm/helm/issues/1707
+tonicStatisticsSeed: "<any-integer>"
 
 # numberOfWorkers will determine how many worker containers are deployed when installing the helm chart.
 numberOfWorkers: 1


### PR DESCRIPTION
hello teams:
  I find a issue related to helm install.  
  when you set the value of **tonicStatisticsSeed** to a large numeric.  helm try to cast it to float64. see details below:

```
[2022-11-22T10:45:12+00:00 ERR Allos.Api] Error on web server startup
Allos.Core.Exceptions.TonicException: Failed to parse TONIC_STATISTICS_SEED VALUE. Must be an integer value, got: '5.837265e+06'
```
  MyValue: 5837265
  ActualValue: 5.837265e+06

  this issue still pending to fix,  so I add the quoted string to this variables. 
  you can go through this issue by: https://github.com/helm/helm/issues/1707 