### PR TITLE
Clarify useUnprivilegedContainers documentation

### DIFF
--- a/templates/tonic-worker-deployment.yaml
+++ b/templates/tonic-worker-deployment.yaml
@@ -60,7 +60,7 @@ spec:
             readOnlyRootFilesystem: true
             {{- end }}
           volumeMounts:
-            {{- if .Values.useUnprivilegedContainers }}
+            {{- if .Values.readOnlyRootFilesystem }}
             - name: var-log
               mountPath: /var/log/supervisor
             - name: var-run

--- a/values.sample.yaml
+++ b/values.sample.yaml
@@ -2,9 +2,13 @@ environmentName: <company-name>
 # useUnprivilegedContainers will pull images that do not run as root if
 # using tonic provided images rather than rehosted customer images
 # additionally it enforces that containers cannot run as root, uses the
-# default runtime security profile, forbids privilege escalation and drops 
+# default runtime security profile, forbids privilege escalation and drops
 # all SYS_CAP privileges. This setting allows tonic to run in restricted
 # environments such as openshift
+# NOTE setting explicit image tags in any of the tonicai services will
+# overwrite the default unprivileged image tags. If you rehost unprivileged
+# images then you should set useUnprivilegedContainers and tonicai service
+# image tags; otherwise you only need to set this flag to true or false
 useUnprivilegedContainers: false
 # setting this to true will run tonic containers with a read only root
 # filesystem and provides necessary emptyDir volume mounts
@@ -61,7 +65,7 @@ tonicai:
   web_server:
     env: {}
     envRaw: {}
-    image: quay.io/tonicai/tonic_web_server
+    #image: quay.io/tonicai/tonic_web_server
     # Comma separated list of user emails that should be have the Admin role in Tonic.
     administrators: example@email.com,other@email.com
     annotations:
@@ -70,14 +74,14 @@ tonicai:
       service.beta.kubernetes.io/azure-load-balancer-internal: "true"
     features:
       # Enables/Disables the HostIntegrations endpoint
-      host_integration_enabled: "true" 
+      host_integration_enabled: "true"
       kubernetes_role: "default"
     ports:
       httpsOnly: true
       https: 443
       http: 80
   worker:
-    image: quay.io/tonicai/tonic_worker
+    #image: quay.io/tonicai/tonic_worker
     env: {}
     envRaw: {}
     ports:
@@ -85,11 +89,11 @@ tonicai:
       https: 443
       http: 80
   notifications:
-    image: quay.io/tonicai/tonic_notifications
+    #image: quay.io/tonicai/tonic_notifications
   pii_detection:
-    image: quay.io/tonicai/tonic_pii_detection
+    #image: quay.io/tonicai/tonic_pii_detection
   pyml_service:
-    image: quay.io/tonicai/tonic_pyml_service
+    #image: quay.io/tonicai/tonic_pyml_service
 #
 # Enterprise License Only: Below are the settings for Single Sign On. Not every provider requires every value. The Tonic support team will help you configure this.
 # tonicSsoConfig:


### PR DESCRIPTION
## What changes by default? 

Nothing! Customers will still pull privileged containers by default. Setting image tags under  services in `tonicai` will still causes those images to take priority. BUT setting these images is only necessary if a customer is rehosting images to a registry they control. 

## What actually changed? 

`useUnprivilegedContainers` is actually a one stop shop for using unprivileged containers if a customer doesn't rehost images to a private registry. `--set useUnprivilegedContainers=true` now causes this helm chart to pull unprivileged images without further customer intervention, previously the images listed under `tonicai` also needed to be updated to  include the `_unprivileged` suffix.

## Customers that rehost unprivileged containers

Customers that rehost unprivileged containers into a private registry will need to set _both_ `useUnprivilegedContainers` to tell the pod to run with unprivileged permissions AND will need to set service images under `tonicai` that point directly towards their rehosted unprivileged images. This chart only sets default images for tonic hosted images and makes no attempt at guessing how a customer may attempt to rehost images.

## What's that bug fix?

Text templating is hard and booleans are harder 😭  

---

## Sample Outputs

Default, this is _just_ `samples.values.yaml`:

```
helm template -f ./values.sample.yaml . | grep quay.io
        image: quay.io/tonicai/tonic_notifications:latest
        image: quay.io/tonicai/tonic_pii_detection:latest
        image: quay.io/tonicai/tonic_pyml_service:latest
        image: quay.io/tonicai/tonic_web_server:latest
          image: quay.io/tonicai/tonic_worker:latest
```

`useUnprivilegedContainers=true`:
```
helm template -f ./values.sample.yaml --set useUnprivilegedContainers=true . | grep quay.io
        image: quay.io/tonicai/tonic_notifications_unprivileged:latest
        image: quay.io/tonicai/tonic_pii_detection_unprivileged:latest
        image: quay.io/tonicai/tonic_pyml_service_unprivileged:latest
        image: quay.io/tonicai/tonic_web_server_unprivileged:latest
          image: quay.io/tonicai/tonic_worker_unprivileged:latest
```

`useUnprivilegedContainers=true` and `tonicai.web_server.image=quay.io/tonicai/example` to override a specific image:
```
helm template -f ./values.sample.yaml --set useUnprivilegedContainers=true --set tonicai.web_server.image=quay.io/tonicai/example  . | grep quay.io
        image: quay.io/tonicai/tonic_notifications_unprivileged:latest
        image: quay.io/tonicai/tonic_pii_detection_unprivileged:latest
        image: quay.io/tonicai/tonic_pyml_service_unprivileged:latest
        image: quay.io/tonicai/example:latest
          image: quay.io/tonicai/tonic_worker_unprivileged:latest
```