### PR TITLE
TN-4574 - Updates for TIM

### DIFF
--- a/templates/ _helpers.tpl
+++ b/templates/ _helpers.tpl
@@ -65,3 +65,11 @@ Create the name of the service account to use
     {{ "" }}
 {{- end -}}
 {{- end }}
+
+{{- define "tonic.hostIntegration" -}}
+{{- if ((.Values.tonicai).web_server).features -}}
+{{- .Values.tonicai.web_server.features.host_integration_enabled -}}
+{{- else -}}
+{{ "false" }}
+{{- end -}}
+{{- end }}

--- a/templates/tonic-image-pull-secret.yaml
+++ b/templates/tonic-image-pull-secret.yaml
@@ -1,3 +1,4 @@
+{{- if ne ((((.Values.tonicai).web_server).features).host_integration_enabled | default "false") "tim" }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -5,3 +6,4 @@ metadata:
 data:
   .dockerconfigjson: {{ .Values.dockerConfigAuth }}
 type: kubernetes.io/dockerconfigjson
+{{- end }}

--- a/templates/tonic-image-pull-secret.yaml
+++ b/templates/tonic-image-pull-secret.yaml
@@ -1,4 +1,4 @@
-{{- if ne ((((.Values.tonicai).web_server).features).host_integration_enabled | default "false") "tim" }}
+{{- if ne (include "tonic.hostIntegration" .) "tim" }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/templates/tonic-rbac.yaml
+++ b/templates/tonic-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if (((.Values.tonicai).web_server).features).host_integration_enabled }}
+{{- if eq ((((.Values.tonicai).web_server).features).host_integration_enabled | default "false") "true" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/templates/tonic-rbac.yaml
+++ b/templates/tonic-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if eq ((((.Values.tonicai).web_server).features).host_integration_enabled | default "false") "true" }}
+{{- if eq (include "tonic.hostIntegration" .) "true" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/templates/tonic-web-server-deployment.yaml
+++ b/templates/tonic-web-server-deployment.yaml
@@ -148,13 +148,13 @@ spec:
               key: secret
               optional: true
           {{- end }}
-        {{- if eq ((((.Values.tonicai).web_server).features).host_integration_enabled | default "false") "true" }}
+        {{- if eq (include "tonic.hostIntegration" .) "true"}}
         - name: TONIC_HOST_INTEGRATION
           value: "kubernetes"
         - name: TONIC_KUBERNETES_NAMESPACE
           value: {{ .Release.Namespace }}
         {{- end }}
-        {{- if eq ((((.Values.tonicai).web_server).features).host_integration_enabled | default "false") "tim" }}
+        {{- if eq (include "tonic.hostIntegration" .) "tim" }}
         - name: TONIC_HOST_INTEGRATION
           value: "TonicInstallationManager"
         {{- end }}

--- a/templates/tonic-web-server-deployment.yaml
+++ b/templates/tonic-web-server-deployment.yaml
@@ -154,6 +154,10 @@ spec:
         - name: TONIC_KUBERNETES_NAMESPACE
           value: {{ .Release.Namespace }}
         {{- end }}
+        {{- if eq ((((.Values.tonicai).web_server).features).host_integration_enabled | default "false") "tim" }}
+        - name: TONIC_HOST_INTEGRATION
+          value: "TonicInstallationManager"
+        {{- end }}
         {{- if .Values.tonicai.web_server.administrators }}
         - name: TONIC_ADMINISTRATORS
           value: {{ .Values.tonicai.web_server.administrators }}


### PR DESCRIPTION
Updating 'host_integration_enabled' to now support true/false/tim.  true/false will operate as normally does for supporting OCU.  "tim" will set the integration type as well as discard the docker authentication as its no longer needed.  TIM handles that directly.