### PR TITLE
Refactor sso configuration / Add generic saml

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -119,9 +119,9 @@ the deployment. This should only be called if $.tonicSsoConfig is populated
 
 {{- define "tonic.sso.azure" -}}
 - name: TONIC_SSO_TENANT_ID
-  value: {{ quote .tenantId }}
+  value: {{ required "tonicSsoConfig.tenantId is required to configure Azure sso" .tenantId | quote }}
 - name: TONIC_SSO_CLIENT_ID
-  value: {{ quote .clientId }}
+  value: {{ required "tonicSsoConfig.clientId is required to configure Azure sso" .clientId | quote }}
 - name: TONIC_SSO_CLIENT_SECRET
   valueFrom:
     secretKeyRef:
@@ -132,9 +132,9 @@ the deployment. This should only be called if $.tonicSsoConfig is populated
 
 {{- define "tonic.sso.duo" -}}
 - name: TONIC_SSO_DOMAIN
-  value: {{ quote .domain }}
+  value: {{ required "tonicSsoConfig.domain is required to configure Duo sso" .domain | quote }}
 - name: TONIC_SSO_CLIENT_ID
-  value: {{ quote .clientId }}
+  value: {{ required "tonicSsoConfig.clientId is required to configure Duo sso" .clientId | quote }}
 - name: TONIC_SSO_CLIENT_SECRET
   valueFrom:
     secretKeyRef:
@@ -145,7 +145,7 @@ the deployment. This should only be called if $.tonicSsoConfig is populated
 
 {{- define "tonic.sso.google" -}}
 - name: TONIC_SSO_DOMAIN
-  value: {{ quote .domain }}
+  value: {{ required "tonicSsoConfig.domain is required to configure Google sso" .domain | quote }}
 - name: TONIC_SSO_SERVICE_ACCOUNT_JSON_BASE64
   valueFrom:
     secretKeyRef:
@@ -156,9 +156,9 @@ the deployment. This should only be called if $.tonicSsoConfig is populated
 
 {{- define "tonic.sso.okta" -}}
 - name: TONIC_SSO_DOMAIN
-  value: {{ quote .domain }}
+  value: {{ required "tonicSsoConfig.domain is required to configure Okta sso" .domain | quote }}
 - name: TONIC_SSO_CLIENT_ID
-  value: {{ quote .clientId }}
+  value: {{ required "tonicSsoConfig.clientId is required to configure Okta sso" .clientId | quote }}
 {{- if .identityProviderId }}
 - name: TONIC_SSO_IDENTITY_PROVIDER_ID
   value: {{ quote .identityProviderId }}
@@ -171,11 +171,11 @@ the deployment. This should only be called if $.tonicSsoConfig is populated
 
 {{- define "tonic.sso.keycloak" -}}
 - name: TONIC_SSO_REALM_ID
-  value: {{ quote .realmId }}
+  value: {{ required "tonicSsoConfig.realmId is required to configure Keycloak sso" .realmId | quote }}
 - name: TONIC_SSO_DOMAIN
-  value: {{ quote .domain }}
+  value: {{ required "tonicSsoConfig.domain is required to configure Keycloak sso" .domain | quote }}
 - name: TONIC_SSO_CLIENT_ID
-  value: {{ quote .clientId }}
+  value: {{ required "tonicSsoConfig.clientId is required to configure Keycloak sso" .clientId | quote }}
 {{- end -}}
 
 {{- define "tonic.sso.generic" -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -82,12 +82,12 @@ the deployment. This should only be called if $.tonicSsoConfig is populated
 {{- $provider := (required "tonicSsoConfig.provider is required for SSO" .provider | lower) -}}
 - name: TONIC_SSO_PROVIDER
   value: {{ quote .provider }}
-{{- if .groupFilter -}}
+{{- if .groupFilter }}
 - name: TONIC_SSO_GROUP_FILTER_REGEX
   value: {{quote .groupFilter}}
-{{- end -}}
+{{- end }}
 {{- if eq $provider "aws" }}
-{{ include "tonic.sso.aws" . }}
+{{- include "tonic.sso.aws" . }}
 {{- else if eq $provider "azure" }}
 {{ include "tonic.sso.azure" . }}
 {{- else if eq $provider "duo" }}
@@ -99,21 +99,24 @@ the deployment. This should only be called if $.tonicSsoConfig is populated
 {{- else if eq $provider "keycloak" }}
 {{ include "tonic.sso.keycloak" . }}
 {{- else if eq $provider "saml" }}
-{{ include "tonic.sso.saml" . }}
-{{- else -}}
-{{- fail "Unsupported SSO provider " .provider -}}
-{{- end -}}
+{{- include "tonic.sso.saml" . }}
+{{- else }}
+{{ fail "Unsupported SSO provider " .provider }}
+{{ end }}
 {{- end -}}
 
 {{- define "tonic.sso.aws" -}}
-{{- if .samlIdpMetadataUrl -}}
+{{- if (.metdataXml).url -}}
 - name: TONIC_SSO_SAML_IDP_METADATA_XML_URL
-  value: {{ quote .samlIdpMetadataUrl }}
+  value: {{ quote .metadataXml.url }}
+{{- else if (.metdataXml).base64 }}
+- name: TONIC_SSO_SAML_IDP_METADATA_XML_BASE64
+  value: {{ quote .metadataXml.base64 }}
 {{- else if .samlIdpMetadataXml }}
 - name: TONIC_SSO_SAML_IDP_METADATA_XML_BASE64
   value: {{ quote .samlIdpMetadataXml }}
 {{- else -}}
-{{ fail "Either samlIdpMetadataUrl or samlIdpMetadataXml must be provided to configre AWS SSO" }}
+{{ fail "Either metadataXml.url, metadataXml.base64 or samlIdpMetadataXml must be provided to configure AWS sso" }}
 {{- end -}}
 {{- end -}}
 
@@ -162,11 +165,11 @@ the deployment. This should only be called if $.tonicSsoConfig is populated
 {{- if .identityProviderId }}
 - name: TONIC_SSO_IDENTITY_PROVIDER_ID
   value: {{ quote .identityProviderId }}
-{{- end -}}
-{{- if .authServerId -}}
+{{- end }}
+{{- if .authServerId }}
 - name: TONIC_SSO_AUTHORIZATION_SERVER_ID
   value: {{ quote .authServerId }}
-{{- end -}}
+{{- end }}
 {{- end -}}
 
 {{- define "tonic.sso.keycloak" -}}
@@ -178,18 +181,18 @@ the deployment. This should only be called if $.tonicSsoConfig is populated
   value: {{ required "tonicSsoConfig.clientId is required to configure Keycloak sso" .clientId | quote }}
 {{- end -}}
 
-{{- define "tonic.sso.generic" -}}
-{{- if .entityId -}}
+{{- define "tonic.sso.saml" -}}
+{{- if .entityId }}
 - name: TONIC_SSO_SAML_ENTITY_ID
   value: {{ quote .entityId }}
-{{- end -}}
-{{- if .metadataXml.url -}}
+{{- end }}
+{{- if .metadataXml.url }}
 - name: TONIC_SSO_SAML_IDP_METADATA_XML_URL
   value: {{ quote .metadataXml.url }}
-{{- else if .metadataXml.base64 -}}
+{{- else if .metadataXml.base64 }}
 - name: TONIC_SSO_SAML_IDP_METADATA_XML_BASE64
   value: {{ quote .metadataXml.base64 }}
-{{- else -}}
-{{ fail "Either metadataXml.url or metadataXml.base64 is required" }}
+{{- else }}
+{{- fail "Either metadataXml.url or metadataXml.base64 is required" }}
 {{- end -}}
 {{- end -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -125,6 +125,9 @@ the deployment. This should only be called if $.tonicSsoConfig is populated
   value: {{ required "tonicSsoConfig.tenantId is required to configure Azure sso" .tenantId | quote }}
 - name: TONIC_SSO_CLIENT_ID
   value: {{ required "tonicSsoConfig.clientId is required to configure Azure sso" .clientId | quote }}
+{{- if not .clientSecret }}
+{{ fail "tonicSsoConfig.clientSecret is required to configure Azure sso" }}
+{{- end }}
 - name: TONIC_SSO_CLIENT_SECRET
   valueFrom:
     secretKeyRef:
@@ -138,6 +141,9 @@ the deployment. This should only be called if $.tonicSsoConfig is populated
   value: {{ required "tonicSsoConfig.domain is required to configure Duo sso" .domain | quote }}
 - name: TONIC_SSO_CLIENT_ID
   value: {{ required "tonicSsoConfig.clientId is required to configure Duo sso" .clientId | quote }}
+{{- if not .clientSecret }}
+{{ fail "tonicSsoConfig.clientSecret is required to configure Duo sso" }}
+{{- end }}
 - name: TONIC_SSO_CLIENT_SECRET
   valueFrom:
     secretKeyRef:
@@ -147,8 +153,22 @@ the deployment. This should only be called if $.tonicSsoConfig is populated
 {{- end -}}
 
 {{- define "tonic.sso.google" -}}
+- name: TONIC_SSO_CLIENT_ID
+  value: {{ required "tonicSsoConfig.clientId is required to configure Google sso" .clientId | quote }}
+{{- if not .clientSecret }}
+{{ fail "tonicSsoConfig.clientSecret is required to configure Google sso" }}
+{{- end }}
+- name: TONIC_SSO_CLIENT_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: tonic-sso-client-secret
+      key: secret
+      optional: false
 - name: TONIC_SSO_DOMAIN
   value: {{ required "tonicSsoConfig.domain is required to configure Google sso" .domain | quote }}
+{{- if not .googleAccountServiceJson }}
+{{ fail "tonicSsoConfig.googleAccountServiceJson is required to configure Google sso"}}
+{{- end }}
 - name: TONIC_SSO_SERVICE_ACCOUNT_JSON_BASE64
   valueFrom:
     secretKeyRef:

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -1,4 +1,3 @@
-{{/* vim: set filetype=mustache: */}}
 {{/*
 Expand the name of the chart.
 */}}
@@ -104,7 +103,12 @@ the deployment. This should only be called if $.Values.tonicSsoConfig is populat
 {{ fail "Unsupported SSO provider " .provider }}
 {{ end }}
 {{- end -}}
+{{/* end tonic.sso */}}
 
+{{/*
+Given $.Values.tonicSsoConfig, produces the environment variables needed to
+configure AWS sso
+*/}}
 {{- define "tonic.sso.aws" -}}
 {{- if (.metdataXml).url -}}
 - name: TONIC_SSO_SAML_IDP_METADATA_XML_URL
@@ -119,7 +123,12 @@ the deployment. This should only be called if $.Values.tonicSsoConfig is populat
 {{ fail "Either metadataXml.url, metadataXml.base64 or samlIdpMetadataXml must be provided to configure AWS sso" }}
 {{- end -}}
 {{- end -}}
+{{/* end tonic.sso.aws */}}
 
+{{/*
+Given $.Values.tonicSsoConfig, produces the environment variables needed to
+configure Azure sso
+*/}}
 {{- define "tonic.sso.azure" -}}
 - name: TONIC_SSO_TENANT_ID
   value: {{ required "tonicSsoConfig.tenantId is required to configure Azure sso" .tenantId | quote }}
@@ -135,7 +144,12 @@ the deployment. This should only be called if $.Values.tonicSsoConfig is populat
       key: secret
       optional: false
 {{- end -}}
+{{/* end tonic.sso.azure */}}
 
+{{/*
+Given $.Values.tonicSsoConfig, produces the environment variables needed to
+configure Duo sso
+*/}}
 {{- define "tonic.sso.duo" -}}
 - name: TONIC_SSO_DOMAIN
   value: {{ required "tonicSsoConfig.domain is required to configure Duo sso" .domain | quote }}
@@ -151,7 +165,12 @@ the deployment. This should only be called if $.Values.tonicSsoConfig is populat
       key: secret
       optional: false
 {{- end -}}
+{{/* end tonic.sso.duo */}}
 
+{{/*
+Given $.Values.tonicSsoConfig, produces the environment variables needed to
+configure Google sso
+*/}}
 {{- define "tonic.sso.google" -}}
 - name: TONIC_SSO_CLIENT_ID
   value: {{ required "tonicSsoConfig.clientId is required to configure Google sso" .clientId | quote }}
@@ -176,7 +195,12 @@ the deployment. This should only be called if $.Values.tonicSsoConfig is populat
       key: secret
       optional: false
 {{- end -}}
+{{/* end tonic.sso.google */}}
 
+{{/*
+Given $.Values.tonicSsoConfig, produces the environment variables needed to
+configure Okta sso
+*/}}
 {{- define "tonic.sso.okta" -}}
 - name: TONIC_SSO_DOMAIN
   value: {{ required "tonicSsoConfig.domain is required to configure Okta sso" .domain | quote }}
@@ -191,7 +215,12 @@ the deployment. This should only be called if $.Values.tonicSsoConfig is populat
   value: {{ quote .authServerId }}
 {{- end }}
 {{- end -}}
+{{/* end tonic.sso.okta */}}
 
+{{/*
+Given $.Values.tonicSsoConfig, produces the environment variables needed to
+configure Keycloak sso
+*/}}
 {{- define "tonic.sso.keycloak" -}}
 - name: TONIC_SSO_REALM_ID
   value: {{ required "tonicSsoConfig.realmId is required to configure Keycloak sso" .realmId | quote }}
@@ -200,7 +229,12 @@ the deployment. This should only be called if $.Values.tonicSsoConfig is populat
 - name: TONIC_SSO_CLIENT_ID
   value: {{ required "tonicSsoConfig.clientId is required to configure Keycloak sso" .clientId | quote }}
 {{- end -}}
+{{/* end tonic.sso.keycloak */}}
 
+{{/*
+Given $.Values.tonicSsoConfig, produces the environment variables needed to
+configure generic saml sso
+*/}}
 {{- define "tonic.sso.saml" -}}
 {{- if .entityId }}
 - name: TONIC_SSO_SAML_ENTITY_ID
@@ -216,3 +250,4 @@ the deployment. This should only be called if $.Values.tonicSsoConfig is populat
 {{- fail "Either metadataXml.url or metadataXml.base64 is required" }}
 {{- end -}}
 {{- end -}}
+{{/* end tonic.sso.saml */}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -75,8 +75,8 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-Given the $.tonicSsoConfig, create all environment variables needed for
-the deployment. This should only be called if $.tonicSsoConfig is populated
+Given the $.Values.tonicSsoConfig, create all environment variables needed for
+the deployment. This should only be called if $.Values.tonicSsoConfig is populated
 */}}
 {{- define "tonic.sso" -}}
 {{- $provider := (required "tonicSsoConfig.provider is required for SSO" .provider | lower) -}}

--- a/templates/tonic-web-server-deployment.yaml
+++ b/templates/tonic-web-server-deployment.yaml
@@ -98,56 +98,9 @@ spec:
               name: tonic-license-secret
               key: license
               optional: true
-          {{- if .Values.tonicSsoConfig }}
-          {{- if .Values.tonicSsoConfig.provider }}
-        - name: TONIC_SSO_PROVIDER
-          value: {{quote .Values.tonicSsoConfig.provider }}
-          {{- end }}
-          {{- if .Values.tonicSsoConfig.domain }}
-        - name: TONIC_SSO_DOMAIN
-          value: {{quote .Values.tonicSsoConfig.domain }}
-          {{- end }}
-          {{- if .Values.tonicSsoConfig.clientId }}
-        - name: TONIC_SSO_CLIENT_ID
-          value: {{quote .Values.tonicSsoConfig.clientId }}
-          {{- end }}
-        - name: TONIC_SSO_CLIENT_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: tonic-sso-client-secret
-              key: secret
-              optional: true
-          {{- if .Values.tonicSsoConfig.identityProviderId }}
-        - name: TONIC_SSO_IDENTITY_PROVIDER_ID
-          value: {{quote .Values.tonicSsoConfig.identityProviderId }}
-          {{- end }}
-          {{- if .Values.tonicSsoConfig.realmId }}
-        - name: TONIC_SSO_REALM_ID
-          value: {{quote .Values.tonicSsoConfig.realmId }}
-          {{- end }}
-          {{- if .Values.tonicSsoConfig.authServerId }}
-        - name: TONIC_SSO_AUTHORIZATION_SERVER_ID
-          value: {{quote .Values.tonicSsoConfig.authServerId }}
-          {{- end }}
-          {{- if .Values.tonicSsoConfig.groupFilter }}
-        - name: TONIC_SSO_GROUP_FILTER_REGEX
-          value: {{quote .Values.tonicSsoConfig.groupFilter }}
-          {{- end }}
-          {{- if .Values.tonicSsoConfig.samlIdpMetadata }}
-        - name: TONIC_SSO_SAML_IDP_METADATA_XML_BASE64
-          value: {{quote .Values.tonicSsoConfig.samlIdpMetadata }}
-          {{- end }}
-          {{- if .Values.tonicSsoConfig.tenantId }}
-        - name: TONIC_SSO_TENANT_ID
-          value: {{quote .Values.tonicSsoConfig.tenantId }}
-          {{- end }}
-        - name: TONIC_SSO_SERVICE_ACCOUNT_JSON_BASE64
-          valueFrom:
-            secretKeyRef:
-              name: tonic-sso-google-account-service-json-secret
-              key: secret
-              optional: true
-          {{- end }}
+        {{- if .Values.tonicSsoConfig }}
+        {{- include "tonic.sso" .Values.tonicSsoConfig | nindent 8 }}
+        {{- end }}
         {{- if eq (include "tonic.hostIntegration" .) "true"}}
         - name: TONIC_HOST_INTEGRATION
           value: "kubernetes"

--- a/values.sample.yaml
+++ b/values.sample.yaml
@@ -106,6 +106,7 @@ tonicai:
 #   provider: AWS
 #   identityProviderId: <identity-provider-id>
 #   samlIdpMetadataXml: <base64 encoded SAML metadata IDP xml>
+#   samlIddMetadataXmlUrl: <url to idp metadata xml>
 
 #   Azure SSO Config
 #   -----------------
@@ -144,6 +145,13 @@ tonicai:
 #   domain: <url-of-keycloak>
 #   realmId: <realm-id>
 
+#   Generic Saml SSO Config
+#   -----------------------
+#   provider: SAML
+#   metadataXml: either url or base64 must be provided, url is given precedence if both are provided
+#     url:
+#     base64:
+#   entityId:  entity id used to send requests from tonic, if not provided, will be determined from metadata xml
 
 # Professional and Enterprise License Only: Configuration options for tonic-notifications.
 # tonicSmtpConfig:

--- a/values.sample.yaml
+++ b/values.sample.yaml
@@ -105,8 +105,12 @@ tonicai:
 #   -----------------
 #   provider: AWS
 #   identityProviderId: <identity-provider-id>
+#   # provided for existing chart installations, new installations should set
+#   # metadataXml.url or metadataXml.base64 instead
 #   samlIdpMetadataXml: <base64 encoded SAML metadata IDP xml>
-#   samlIddMetadataXmlUrl: <url to idp metadata xml>
+#   metdataXml:
+#     url: <url to metadata xml, given priority>
+#     base64: <base64 encoded SAML metadata IDP xml>
 
 #   Azure SSO Config
 #   -----------------
@@ -125,8 +129,6 @@ tonicai:
 #   Google SSO Config
 #   -----------------
 #   provider: Google
-#   clientId: <client-id>
-#   clientSecret: <client-secret>
 #   domain: <sso-domain>
 #   googleAccountServiceJson: <base64 encoded version of your service account json>
 
@@ -148,10 +150,10 @@ tonicai:
 #   Generic Saml SSO Config
 #   -----------------------
 #   provider: SAML
-#   metadataXml: either url or base64 must be provided, url is given precedence if both are provided
-#     url:
-#     base64:
-#   entityId:  entity id used to send requests from tonic, if not provided, will be determined from metadata xml
+#   metadataXml:
+#     url: <url to metadataXml, given priority>
+#     base64: <base64 encoded metadataXml>
+#   entityId: <entity id used to send requests from tonic, if not provided, will be determined from metadata xml>
 
 # Professional and Enterprise License Only: Configuration options for tonic-notifications.
 # tonicSmtpConfig:

--- a/values.sample.yaml
+++ b/values.sample.yaml
@@ -128,6 +128,8 @@ tonicai:
 
 #   Google SSO Config
 #   -----------------
+#   clientId: <client-id>
+#   clientSecret: <client-secret>
 #   provider: Google
 #   domain: <sso-domain>
 #   googleAccountServiceJson: <base64 encoded version of your service account json>


### PR DESCRIPTION
Instead of having a long, complicated combination of if checks in the deployment file, this pulls all SSO envvars out to a named template that delegates to another named template that produces either the needed SSO envvars or fails with an error message if a required property is not set. 