### PR TITLE
Update default annotations and documentation for web server service

### DIFF
--- a/templates/tonic-web-server-service.yaml
+++ b/templates/tonic-web-server-service.yaml
@@ -8,12 +8,6 @@ metadata:
 {{- if  ((.Values.tonicai).web_server).annotations }}
   annotations:
     {{- toYaml .Values.tonicai.web_server.annotations | nindent 4 }}
-{{- else }}
-  annotations:
-    service.beta.kubernetes.io/aws-load-balancer-internal: "true"
-    service.beta.kubernetes.io/azure-load-balancer-internal: "true"
-    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
-    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
 {{- end }}
 
   labels:

--- a/templates/tonic-web-server-service.yaml
+++ b/templates/tonic-web-server-service.yaml
@@ -8,6 +8,13 @@ metadata:
 {{- if  ((.Values.tonicai).web_server).annotations }}
   annotations:
     {{- toYaml .Values.tonicai.web_server.annotations | nindent 4 }}
+{{- else }}
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+    service.beta.kubernetes.io/aws-load-balancer-scheme: "internal"
+    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+    service.beta.kubernetes.io/azure-load-balancer-internal: "true"
 {{- end }}
 
   labels:

--- a/values.sample.yaml
+++ b/values.sample.yaml
@@ -68,10 +68,12 @@ tonicai:
     #image: quay.io/tonicai/tonic_web_server
     # Comma separated list of user emails that should be have the Admin role in Tonic.
     administrators: example@email.com,other@email.com
-    annotations:
-      # This annotation is only required if you are creating an internal facing ELB. Remove this annotation to create public facing ELB.
-      service.beta.kubernetes.io/aws-load-balancer-internal: "true"
-      service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+    # annotations to apply to the service that routes traffic to the web server
+    annotations: {}
+      # For instructions on creating a load balancer to Tonic web server, see documentation from your cloud provider
+      # AWS: https://docs.aws.amazon.com/eks/latest/userguide/network-load-balancing.html
+      # Azure: https://learn.microsoft.com/en-us/azure/aks/internal-lb
+      # GCP: https://cloud.google.com/kubernetes-engine/docs/concepts/service-load-balancer
     features:
       # Enables/Disables the HostIntegrations endpoint
       host_integration_enabled: "true"

--- a/values.sample.yaml
+++ b/values.sample.yaml
@@ -70,8 +70,12 @@ tonicai:
     administrators: example@email.com,other@email.com
     # annotations to apply to the service that routes traffic to the web server
     annotations: {}
-      # For instructions on creating a load balancer to Tonic web server, see documentation from your cloud provider
+      # By default this chart will create an internal load balancer service on
+      # EKS and AKS; however, providing additional annotations will disable this
+      # If additional annotations are applied and you need a load balancer to
+      # the Tonic installation see documentation from your cloud provider
       # AWS: https://docs.aws.amazon.com/eks/latest/userguide/network-load-balancing.html
+      #      https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.5/
       # Azure: https://learn.microsoft.com/en-us/azure/aks/internal-lb
       # GCP: https://cloud.google.com/kubernetes-engine/docs/concepts/service-load-balancer
     features:


### PR DESCRIPTION
Updates EKS annotations to include the replacement for `aws-load-balancer-internal: true` 

https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.5/guide/service/annotations/#lb-scheme

Provides updated documentation on the load balancer creation as default plus links to documentation for AWS, Azure and GCP on annotations that could be applied if specific behavior is needed.