### PR TITLE
Parameterize Resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,3 @@ Session.vim
 .netrwhist
 **/charts/*.tgz
 .history
-values.yaml

--- a/templates/tonic-notifications-deployment.yaml
+++ b/templates/tonic-notifications-deployment.yaml
@@ -121,11 +121,9 @@ spec:
             mountPath: /tmp
           {{- end }}
         resources:
-          limits:
-            memory: "1Gi"
-          requests:
-            memory: "512Mi"
-            ephemeral-storage: "1Gi"
+          {{- with .Values.resources.notifications }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
         ports:
         - containerPort: 7000
         - containerPort: 7001

--- a/templates/tonic-pyml-deployment.yaml
+++ b/templates/tonic-pyml-deployment.yaml
@@ -85,14 +85,9 @@ spec:
         ports:
         - containerPort: 7700
         resources:
-          limits:
-            memory: "8Gi"
-            {{- if ((.Values.resources).pyml_gpu).amount }}
-            nvidia.com/gpu: {{ .Values.resources.pyml_gpu.amount }}
-            {{- end }}
-          requests:
-            memory: "512Mi"
-            ephemeral-storage: "1Gi"
+          {{- with .Values.resources.pyml_service }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
         startupProbe:
           httpGet:
             path: /health

--- a/templates/tonic-web-server-deployment.yaml
+++ b/templates/tonic-web-server-deployment.yaml
@@ -140,11 +140,9 @@ spec:
         - containerPort: {{ $httpsPort }}
           name: "https"
         resources:
-          limits:
-            memory: "3Gi"
-          requests:
-            memory: "2Gi"
-            ephemeral-storage: "1Gi"
+          {{- with .Values.resources.web_server }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
         startupProbe:
           httpGet:
             scheme: HTTPS

--- a/templates/tonic-worker-deployment.yaml
+++ b/templates/tonic-worker-deployment.yaml
@@ -146,11 +146,9 @@ spec:
           - containerPort: {{ $httpsPort }}
             name: "https"
           resources:
-            limits:
-              memory: "12Gi"
-            requests:
-              memory: "6Gi"
-              ephemeral-storage: "1Gi"
+            {{- with .Values.resources.worker }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           startupProbe:
             httpGet:
               scheme: HTTPS

--- a/values.yaml
+++ b/values.yaml
@@ -1,0 +1,26 @@
+# Default resource requests and limits used by the Tonic services.
+resources:
+  notifications:
+    requests:
+      memory: "512Mi"
+      ephemeral-storage: "1Gi"
+    limits:
+      memory: "1Gi"
+  pyml_service:
+    requests:
+      memory: "512Mi"
+      ephemeral-storage: "1Gi"
+    limits:
+      memory: "8Gi"
+  web_server:
+    requests:
+      memory: "2Gi"
+      ephemeral-storage: "1Gi"
+    limits:
+      memory: "3Gi"
+  worker:
+    requests:
+      memory: "6Gi"
+      ephemeral-storage: "1Gi"
+    limits:
+      memory: "12Gi"


### PR DESCRIPTION
Allow resource requests and limits to be configured for individual installations.

The current values are defaulted in the default `values.yaml`.