### PR TITLE
Conditionally Create Secrets

### DIFF
--- a/templates/tonic-db-secret.yaml
+++ b/templates/tonic-db-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.tonicdb.password }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -5,3 +6,4 @@ metadata:
 type: Opaque
 data:
   password: {{ .Values.tonicdb.password | b64enc }}
+{{- end }}

--- a/templates/tonic-image-pull-secret.yaml
+++ b/templates/tonic-image-pull-secret.yaml
@@ -1,4 +1,5 @@
 {{- if ne (include "tonic.hostIntegration" .) "tim" }}
+{{- if .Values.dockerConfigAuth }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,4 +7,5 @@ metadata:
 data:
   .dockerconfigjson: {{ .Values.dockerConfigAuth }}
 type: kubernetes.io/dockerconfigjson
+{{- end }}
 {{- end }}


### PR DESCRIPTION
This allows organizations to use other mechanisms for secret management without plaintext passwords by not specifying the passwords directly in their values.