### PR TITLE
Allow Services to be Exposed via HTTP

### DIFF
--- a/templates/tonic-web-server-deployment.yaml
+++ b/templates/tonic-web-server-deployment.yaml
@@ -12,7 +12,7 @@
   {{- end }}
 {{- end }}
 {{- $ports := ((.Values.tonicai).web_server).ports | default dict }}
-{{- $httpsOnly := $ports.httpsOnly | default true }}
+{{- $httpsOnly := hasKey $ports "httpsOnly" | ternary $ports.httpsOnly true }}
 {{- $httpPort := $ports.http | default 6580 }}
 {{- $httpsPort := $ports.https | default 6543 }}
 apiVersion: apps/v1

--- a/templates/tonic-web-server-service.yaml
+++ b/templates/tonic-web-server-service.yaml
@@ -1,4 +1,6 @@
 {{- $ports := ((.Values.tonicai).web_server).ports | default dict }}
+{{- $httpsOnly := hasKey $ports "httpsOnly" | ternary $ports.httpsOnly true }}
+{{- $httpPort := $ports.http | default 6580 }}
 {{- $httpsPort := $ports.https | default 6543 }}
 apiVersion: v1
 kind: Service
@@ -21,6 +23,11 @@ metadata:
     app: tonic-web-server
 spec:
   ports:
+  {{- if not $httpsOnly }}
+  - name: "http"
+    port: 80
+    targetPort: {{ $httpPort }}
+  {{- end }}
   - name: "https"
     port: 443
     targetPort: {{ $httpsPort }}

--- a/templates/tonic-worker-deployment.yaml
+++ b/templates/tonic-worker-deployment.yaml
@@ -12,7 +12,7 @@
   {{- end }}
 {{- end }}
 {{- $ports := ((.Values.tonicai).worker).ports | default dict }}
-{{- $httpsOnly := $ports.httpsOnly | default true }}
+{{- $httpsOnly := hasKey $ports "httpsOnly" | ternary $ports.httpsOnly true }}
 {{- $httpPort := $ports.http | default 2480 }}
 {{- $httpsPort := $ports.https | default 2467 }}
 apiVersion: apps/v1

--- a/templates/tonic-worker-service.yaml
+++ b/templates/tonic-worker-service.yaml
@@ -1,5 +1,5 @@
 {{- $workerPorts := ((.Values.tonicai).worker).ports | default dict }}
-{{- $httpsOnly := $workerPorts.httpsOnly | default true }}
+{{- $httpsOnly := hasKey $workerPorts "httpsOnly" | ternary $workerPorts.httpsOnly true }}
 {{- $httpPort := $workerPorts.http | default 2480 }}
 {{- $httpsPort := $workerPorts.https | default 2467 }}
 apiVersion: v1


### PR DESCRIPTION
Allow services to be exposed via HTTP.

The use of the `default` function had the unintended side-effect of never allowing the value to be `false`.

See the following for more details:
- [helm/helm#3308](https://github.com/helm/helm/issues/3308)
- [Masterminds/sprig#111](https://github.com/Masterminds/sprig/issues/111)
- [Default Functions](http://masterminds.github.io/sprig/defaults.html)