### PR TITLE
Allow services to be exposed via HTTP.

### DIFF
--- a/templates/tonic-web-server-deployment.yaml
+++ b/templates/tonic-web-server-deployment.yaml
@@ -2,8 +2,8 @@
 {{- $resources := coalesce
   $server.resources
   (dict "limits" (dict "memory" "3Gi") "requests" (dict "memory" "2Gi" "ephemeral-storage" "1Gi")) -}}
-{{- $ports := $server.ports | default dict }}
-{{- $httpsOnly := $ports.httpsOnly | default true }}
+{{- $ports := ((.Values.tonicai).web_server).ports | default dict }}
+{{- $httpsOnly := hasKey $ports "httpsOnly" | ternary $ports.httpsOnly true }}
 {{- $httpPort := $ports.http | default 6580 }}
 {{- $httpsPort := $ports.https | default 6543 }}
 apiVersion: apps/v1

--- a/templates/tonic-web-server-service.yaml
+++ b/templates/tonic-web-server-service.yaml
@@ -1,4 +1,6 @@
 {{- $ports := ((.Values.tonicai).web_server).ports | default dict }}
+{{- $httpsOnly := hasKey $ports "httpsOnly" | ternary $ports.httpsOnly true }}
+{{- $httpPort := $ports.http | default 6580 }}
 {{- $httpsPort := $ports.https | default 6543 }}
 {{- $annotations := dict }}
 {{- if ((.Values.tonicai).web_server).annotations }}
@@ -23,6 +25,11 @@ metadata:
     {{- include "tonic.allLabels" (list $ (dict "app" "tonic-web-server")) | nindent 4 }}
 spec:
   ports:
+  {{- if not $httpsOnly }}
+  - name: "http"
+    port: 80
+    targetPort: {{ $httpPort }}
+  {{- end }}
   - name: "https"
     port: 443
     targetPort: {{ $httpsPort }}

--- a/templates/tonic-worker-deployment.yaml
+++ b/templates/tonic-worker-deployment.yaml
@@ -13,7 +13,7 @@
   {{- end }}
 {{- end }}
 {{- $ports := ((.Values.tonicai).worker).ports | default dict }}
-{{- $httpsOnly := $ports.httpsOnly | default true }}
+{{- $httpsOnly := hasKey $ports "httpsOnly" | ternary $ports.httpsOnly true }}
 {{- $httpPort := $ports.http | default 2480 }}
 {{- $httpsPort := $ports.https | default 2467 }}
 apiVersion: apps/v1

--- a/templates/tonic-worker-service.yaml
+++ b/templates/tonic-worker-service.yaml
@@ -1,5 +1,5 @@
 {{- $workerPorts := ((.Values.tonicai).worker).ports | default dict }}
-{{- $httpsOnly := $workerPorts.httpsOnly | default true }}
+{{- $httpsOnly := hasKey $workerPorts "httpsOnly" | ternary $workerPorts.httpsOnly true }}
 {{- $httpPort := $workerPorts.http | default 2480 }}
 {{- $httpsPort := $workerPorts.https | default 2467 }}
 apiVersion: v1


### PR DESCRIPTION
The use of the `default` function had the unintended side-effect of never allowing the value to be `false`.

See the following for more details:
- [helm/helm#3308](https://github.com/helm/helm/issues/3308)
- [Masterminds/sprig#111](https://github.com/Masterminds/sprig/issues/111)
- [Default Functions](http://masterminds.github.io/sprig/defaults.html)