### PR TITLE
TN-46937: Make port selection smarter

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -453,9 +453,6 @@ caller (which is ideally the root value of the chart).
 {{- if $thesePorts.httpsOnly }}
 {{- $_ := set $thesePorts "http" $http }}
 {{- end }}
-{{- if 1 }}
-{{- $_ := set $thesePorts "inputs" (dict "defaults" $defaults "passed" $passed "useUnprivilegedContainers" $useUnprivileged) }}
-{{- end }}
 {{ toYaml $thesePorts }}
 {{- end }}
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -450,7 +450,7 @@ caller (which is ideally the root value of the chart).
 {{- end }}
 {{/* break most places the http port would be placed if it's erronously accessed */}}
 {{- $thesePorts := (dict "http" "HTTP PORT NOT AVAILABLE" "https" $https "httpsOnly" $httpsOnly) }}
-{{- if $thesePorts.httpsOnly }}
+{{- if not $thesePorts.httpsOnly }}
 {{- $_ := set $thesePorts "http" $http }}
 {{- end }}
 {{ toYaml $thesePorts }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -406,3 +406,65 @@ caller (which is ideally the root value of the chart).
 {{- $version := (index . 3) |  default "latest" }}
 {{- include "tonic.image" (list $top $custImage $ourImage) }}:{{ $version }}
 {{- end }}
+
+{{/* usage:
+    $ports := fromYaml (include "tonic.ports" (list $ $service.ports (dict "http" 1337 "https" 31337 "httpsOnly" true)))
+*/}}
+{{- define "tonic.ports" -}}
+{{- $top := first . }}
+{{- $passed := dict }}
+{{- if and (gt (len .) 1) (index . 1) }}
+{{ $passed = index . 1 }}
+{{- end }}
+{{- $defaults := dict }}
+{{- if and (gt (len .) 2) (index . 2) }}
+{{- $defaults = index . 2 }}
+{{- end }}
+{{- $useUnprivileged := false }}
+{{- if hasKey $top.Values "useUnprivilegedContainers" }}
+{{ $useUnprivileged = $top.Values.useUnprivilegedContainers }}
+{{- end }}
+{{- $unprivilegedHttp := 8080 }}
+{{- if and $defaults.http (lt 1024 $defaults.http) }}
+{{- $unprivilegedHttp = $defaults.http }}
+{{- end }}
+{{- $unprivilegedHttps := 8443 }}
+{{- if and $defaults.https (lt 1024 $defaults.https) }}
+{{- $unprivilegedHttps = $defaults.https }}
+{{- end }}
+{{- $http := int (coalesce $passed.http $defaults.http $unprivilegedHttp) }}
+{{- $https := int (coalesce $passed.https $defaults.https $unprivilegedHttps) }}
+{{/* `$passed.httpsOnly | default true` flips an explicit false off */}}
+{{- $httpsOnly := true }}
+{{- if hasKey $passed "httpsOnly" }}
+{{- $httpsOnly = $passed.httpsOnly }}
+{{- else if hasKey $defaults "httpsOnly" }}
+{{- $httpsOnly = $defaults.httpsOnly }}
+{{- end }}
+{{/* 1024 is usually where privileged ports end */}}
+{{- if and $useUnprivileged (ge 1024 $http) -}}
+{{- $http = $unprivilegedHttp }}
+{{- end }}
+{{- if and $useUnprivileged (ge 1024 $https) -}}
+{{- $https = $unprivilegedHttps }}
+{{- end }}
+{{/* break most places the http port would be placed if it's erronously accessed */}}
+{{- $thesePorts := (dict "http" "HTTP PORT NOT AVAILABLE" "https" $https "httpsOnly" $httpsOnly) }}
+{{- if $thesePorts.httpsOnly }}
+{{- $_ := set $thesePorts "http" $http }}
+{{- end }}
+{{- if 1 }}
+{{- $_ := set $thesePorts "inputs" (dict "defaults" $defaults "passed" $passed "useUnprivilegedContainers" $useUnprivileged) }}
+{{- end }}
+{{ toYaml $thesePorts }}
+{{- end }}
+
+{{- define "tonic.web.serviceType" -}}
+{{- $top := first . }}
+{{- $useIngress := $top.Values.tonicai.use_ingress }}
+{{- if $useIngress }}
+{{- printf "ClusterIP" }}
+{{- else }}
+{{- printf "LoadBalancer" }}
+{{- end }}
+{{- end }}

--- a/templates/tonic-notifications-deployment.yaml
+++ b/templates/tonic-notifications-deployment.yaml
@@ -4,6 +4,7 @@
   $notifications.resources
   (dict "limits" (dict "memory" "1Gi") "requests" (dict "memory" "512Mi" "ephemeral-storage" "1Gi"))
 -}}
+{{- $ports := fromYaml (include "tonic.ports" (list $ (dict "http" 7000 "https" 7001))) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -108,9 +109,9 @@ spec:
         - name: ENVIRONMENT_NAME
           value: {{ .Values.environmentName }}
         - name: TONIC_NOTIFICATIONS_HEALTH_PORT_HTTP
-          value: "7000"
+          value: {{ $ports.http | quote }}
         - name: TONIC_NOTIFICATIONS_HEALTH_PORT_HTTPS
-          value: "7001"
+          value: {{ $ports.https | quote }}
         {{- if $notifications.envFrom }}
         envFrom:
         {{- with $notifications.envFrom }}
@@ -139,13 +140,15 @@ spec:
         resources:
           {{- toYaml $resources | nindent 10 }}
         ports:
-        - containerPort: 7000
-        - containerPort: 7001
+        - containerPort: {{ $ports.http | quote }}
+          name: http
+        - containerPort: {{ $ports.https | quote }}
+          name: https
         startupProbe:
           httpGet:
             scheme: HTTPS
             path: /health
-            port: 7001
+            port: https
           initialDelaySeconds: 5
           periodSeconds: 60
           timeoutSeconds: 30

--- a/templates/tonic-notifications-service.yaml
+++ b/templates/tonic-notifications-service.yaml
@@ -11,10 +11,10 @@ spec:
   ports:
   - name: "7000"
     port: 7000
-    targetPort: 7000
+    targetPort: http
   - name: "7001"
     port: 7001
-    targetPort: 7001
+    targetPort: https
   selector:
     app: tonic-notifications
 status:

--- a/templates/tonic-pyml-deployment.yaml
+++ b/templates/tonic-pyml-deployment.yaml
@@ -14,6 +14,7 @@
   $pyml.tolerations
   list
 ) -}}
+{{- $ports := fromYaml (include "tonic.ports" (list $ (dict "https" 7700 )))  }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -108,13 +109,14 @@ spec:
             mountPath: /publish/logs
           {{- end }}
         ports:
-        - containerPort: 7700
+        - containerPort: {{ $ports.https }}
+          name: https
         resources:
           {{- toYaml $resources | nindent 10 }}
         startupProbe:
           httpGet:
             path: /health
-            port: 7700
+            port: https
             scheme: HTTPS
           initialDelaySeconds: 5
           periodSeconds: 60

--- a/templates/tonic-pyml-service.yaml
+++ b/templates/tonic-pyml-service.yaml
@@ -10,8 +10,7 @@ metadata:
 spec:
   ports:
   - port: 7700
-    targetPort: 7700
+    targetPort: https
+    name: https
   selector:
     app: tonic-pyml-service
-status:
-  loadBalancer: {}

--- a/templates/tonic-web-server-deployment.yaml
+++ b/templates/tonic-web-server-deployment.yaml
@@ -2,10 +2,10 @@
 {{- $resources := coalesce
   $server.resources
   (dict "limits" (dict "memory" "3Gi") "requests" (dict "memory" "2Gi" "ephemeral-storage" "1Gi")) -}}
-{{- $ports := ((.Values.tonicai).web_server).ports | default dict }}
-{{- $httpsOnly := hasKey $ports "httpsOnly" | ternary $ports.httpsOnly true }}
-{{- $httpPort := $ports.http | default 6580 }}
-{{- $httpsPort := $ports.https | default 6543 }}
+{{- $ports := fromYaml (include "tonic.ports" (list $ $server.ports (dict "http" 6580 "https" 6543 "httpsOnly" true)))  }}
+{{- $httpsOnly := $ports.httpsOnly }}
+{{- $httpPort := $ports.http }}
+{{- $httpsPort := $ports.https }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/templates/tonic-web-server-service.yaml
+++ b/templates/tonic-web-server-service.yaml
@@ -1,7 +1,5 @@
-{{- $ports := ((.Values.tonicai).web_server).ports | default dict }}
-{{- $httpsOnly := hasKey $ports "httpsOnly" | ternary $ports.httpsOnly true }}
-{{- $httpPort := $ports.http | default 6580 }}
-{{- $httpsPort := $ports.https | default 6543 }}
+{{- $server := .Values.tonicai.web_server -}}
+{{- $ports := fromYaml (include "tonic.ports" (list $ $server.ports (dict "httpsOnly" true)))  }}
 {{- $annotations := dict }}
 {{- if ((.Values.tonicai).web_server).annotations }}
 {{- $annotations = .Values.tonicai.web_server.annotations }}
@@ -14,6 +12,7 @@
     "service.beta.kubernetes.io/azure-load-balancer-internal" "true"
 )}}
 {{- end }}
+{{- $serviceType := include "tonic.web.serviceType" (list $) }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -25,20 +24,15 @@ metadata:
     {{- include "tonic.allLabels" (list $ (dict "app" "tonic-web-server")) | nindent 4 }}
 spec:
   ports:
-  {{- if not $httpsOnly }}
+  {{- if not $ports.httpsOnly }}
   - name: "http"
     port: 80
-    targetPort: {{ $httpPort }}
+    targetPort: http
   {{- end }}
   - name: "https"
     port: 443
-    targetPort: {{ $httpsPort }}
-# use_ingress typically only used by TIM
-{{- if (.Values.tonicai).use_ingress }}
-  type: ClusterIP
-{{- else }}
-  type: LoadBalancer
-{{- end }}
+    targetPort: https
+  type: {{ $serviceType }}
   selector:
     app: tonic-web-server
 status:

--- a/templates/tonic-worker-deployment.yaml
+++ b/templates/tonic-worker-deployment.yaml
@@ -12,10 +12,10 @@
   {{- $image = "" }}
   {{- end }}
 {{- end }}
-{{- $ports := ((.Values.tonicai).worker).ports | default dict }}
-{{- $httpsOnly := hasKey $ports "httpsOnly" | ternary $ports.httpsOnly true }}
-{{- $httpPort := $ports.http | default 2480 }}
-{{- $httpsPort := $ports.https | default 2467 }}
+{{- $ports := fromYaml (include "tonic.ports" (list $ $worker.ports (dict "http" 2480 "https" 2467 "httpsOnly" true)))  }}
+{{- $httpsOnly := $ports.httpsOnly }}
+{{- $httpPort := $ports.http }}
+{{- $httpsPort := $ports.https }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -175,7 +175,7 @@ spec:
             httpGet:
               scheme: HTTPS
               path: /health
-              port: {{ $httpsPort }}
+              port: https
             initialDelaySeconds: 5
             periodSeconds: 60
             timeoutSeconds: 30

--- a/templates/tonic-worker-service.yaml
+++ b/templates/tonic-worker-service.yaml
@@ -1,7 +1,5 @@
-{{- $workerPorts := ((.Values.tonicai).worker).ports | default dict }}
-{{- $httpsOnly := hasKey $workerPorts "httpsOnly" | ternary $workerPorts.httpsOnly true }}
-{{- $httpPort := $workerPorts.http | default 2480 }}
-{{- $httpsPort := $workerPorts.https | default 2467 }}
+{{- $worker := .Values.tonicai.worker }}
+{{- $ports := fromYaml (include "tonic.ports" (list $ $worker.ports (dict "httpsOnly" true)))  }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -13,14 +11,14 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   ports:
-  {{- if not $httpsOnly }}
+  {{- if not $ports.httpsOnly }}
   - name: "8080"
     port: 8080
-    targetPort: {{ $httpPort }}
+    targetPort: http
   {{- end }}
   - name: "4433"
     port: 4433
-    targetPort: {{ $httpsPort }}
+    targetPort: https
   selector:
     app: tonic-worker
 status:

--- a/values.sample.yaml
+++ b/values.sample.yaml
@@ -1,4 +1,5 @@
 environmentName: <company-name>
+  #
 # useUnprivilegedContainers will pull images that do not run as root if
 # using tonic provided images rather than rehosted customer images
 # additionally it enforces that containers cannot run as root, uses the


### PR DESCRIPTION
Installing the chart with `useUnprivilegedContainers: true` will cause all containers to bind to ports above 1024, even if explicitly set below 1024. All containers provide default ports above 1024. Ports on services are not affected.

Closes #94 
cc @msn-resy

Attached are runs of `helm template -f values.sample.yaml .`:
* [`--set useUnprivilegedContainers=false`](https://github.com/user-attachments/files/16553546/useUnprivileged.false.md)
* [`--set useUnprivilegedContainers=true`](https://github.com/user-attachments/files/16553547/useUnprivileged.true.md)

```
helm template -f values.sample.yaml . \
  --set useUnprivilegedContainers=true \
  --set tonicai.web_server.ports.https=443 \
  -s templates/tonic-web-server-deployment.yaml | grep -C 2 6543 

          value: https://tonic-pyml-service:7700
        - name: TONIC_PORT_HTTPS
          value: "6543"
        - name: TONIC_HTTPS_ONLY
          value: "true"
--
        name: tonic-web-server
        ports:
        - containerPort: 6543
          name: "https"
        resources:
--
            scheme: HTTPS
            path: /health
            port: 6543
          initialDelaySeconds: 5
          periodSeconds: 60
```

```
helm template -f values.sample.yaml . \ 
  --set useUnprivilegedContainers=true  \
  --set tonicai.worker.ports.https=10443 \
  -s templates/tonic-worker-deployment.yaml | grep -C 2 10443 

              value: "true"
            - name: TONIC_WORKER_HEALTH_PORT_HTTPS
              value: "10443"
          image: quay.io/tonicai/tonic_worker_unprivileged:latest
          imagePullPolicy: Always
          name: tonic-worker
          ports:
          - containerPort: 10443
            name: "https"
          resources:
```

