### PR TITLE
Only attach pull secret when provided to chart

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -493,3 +493,14 @@ caller (which is ideally the root value of the chart).
   {{- end }}
 {{- end }}
 {{- end }}
+
+{{- define "tonic.imagePullSecret.default" -}}
+{{- $top := first . }}
+{{- if $top.Values.dockerConfigAuth }}
+- name: {{ include "tonic.imagePullSecret.defaultName" $top }}
+{{- end }}
+{{- end }}
+
+{{- define "tonic.imagePullSecret.defaultName" -}}
+tonicai-build-writer-pull-secret
+{{- end }}

--- a/templates/tonic-image-pull-secret.yaml
+++ b/templates/tonic-image-pull-secret.yaml
@@ -4,7 +4,7 @@ kind: Secret
 metadata:
   annotations:
     {{- include "tonic.annotations" (list $) | nindent 4 }}
-  name: tonicai-build-writer-pull-secret
+  name: {{ include "tonic.imagePullSecret.defaultName" $ }}
 data:
   .dockerconfigjson: {{ .Values.dockerConfigAuth }}
 type: kubernetes.io/dockerconfigjson

--- a/templates/tonic-notifications-deployment.yaml
+++ b/templates/tonic-notifications-deployment.yaml
@@ -156,7 +156,7 @@ spec:
           failureThreshold: 5
       restartPolicy: Always
       imagePullSecrets:
-      - name: tonicai-build-writer-pull-secret
+      {{- include "tonic.imagePullSecret.default" (list $) | nindent 8 }}
       serviceAccountName: {{ template "tonic.serviceAccountName" . }}
       volumes:
         {{- if $notifications.volumes }}

--- a/templates/tonic-web-server-deployment.yaml
+++ b/templates/tonic-web-server-deployment.yaml
@@ -161,7 +161,7 @@ spec:
       restartPolicy: Always
       serviceAccountName: {{ template "tonic.serviceAccountName" . }}
       imagePullSecrets:
-      - name: tonicai-build-writer-pull-secret
+      {{- include "tonic.imagePullSecret.default" (list $) | nindent 8 }}
       volumes:
       {{- if $server.volumes }}
       {{- toYaml $server.volumes | nindent 8 }}

--- a/templates/tonic-worker-deployment.yaml
+++ b/templates/tonic-worker-deployment.yaml
@@ -184,6 +184,6 @@ spec:
             failureThreshold: 5
       restartPolicy: Always
       imagePullSecrets:
-      - name: tonicai-build-writer-pull-secret
+      {{- include "tonic.imagePullSecret.default" (list $) | nindent 8 }}
       serviceAccountName: {{ template "tonic.serviceAccountName" . }}
 status: {}


### PR DESCRIPTION
We're moving our production to using ECR and authorization is negotiated through the nodes' IAM role rather than a secret in the namespace.  The secret was already optionally generated, this extends that optionality to the deployments that use it.