### PR TITLE
Attach roles/clusterroles to service account

### DIFF
--- a/templates/tonic-serviceaccount-bindings.yaml
+++ b/templates/tonic-serviceaccount-bindings.yaml
@@ -1,0 +1,43 @@
+{{- define "kubernetes.rbac.binding" }}
+{{- $top := first . }}
+{{- $kind := index . 1}}
+{{- $serviceAccountName := index . 2 }}
+{{- $role := index . 3 }}
+{{- $labels := index . 4 }}
+{{- $annotations := index . 5 }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: {{ $kind }}
+metadata:
+  annotations:
+    {{- include "tonic.annotations" (list $top $annotations) | nindent 4 }}
+  labels:
+    {{- include "tonic.allLabels" (list $top $labels) | nindent 4 }}
+  name: {{ $serviceAccountName }}-{{ $role.name }}
+  namespace: {{ $top.Release.Namespace }}
+roleRef:
+  {{- (toYaml $role) | nindent 2 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ $serviceAccountName }}
+  namespace: {{ $top.Release.Namespace }}
+{{- end }}
+
+{{- define "tonic.serviceAccount.bindings" }}
+{{- $top := first . }}
+{{- $kind := index . 1 }}
+{{- $serviceAccountName := index . 2 }}
+{{- $definition := index . 3 }}
+{{- if and $definition $definition.bindings }}
+{{- $labels := $definition.labels }}
+{{- $annotations := $definition.annotations }}
+{{- range $role := $definition.bindings }}
+{{ include "kubernetes.rbac.binding" (list $top $kind $serviceAccountName $role $labels $annotations) }}
+---
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- $serviceAccountName := (include "tonic.serviceAccountName" .) }}
+{{- include "tonic.serviceAccount.bindings" (list $ "RoleBinding" $serviceAccountName .Values.serviceAccount.roleBindings) }}
+{{- include "tonic.serviceAccount.bindings" (list $ "ClusterRoleBinding" $serviceAccountName .Values.serviceAccount.clusterRoleBindings) }}
+

--- a/values.sample.yaml
+++ b/values.sample.yaml
@@ -39,6 +39,24 @@ dockerConfigAuth: <docker-config-auth>
 serviceAccount:
   create: true
   annotations: {}
+  # see: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#rolebinding-and-clusterrolebinding
+  roleBindings:
+    annotations: {}
+    labels: {}
+    bindings:
+    # - apiGroup: rbac.authorization.k8s.io
+    #   kind: ClusterRole
+    #   name: my-cluster-role
+    # - apiGroup: rbac.authorization.k8s.io
+    #   kind: Role
+    #   name: my-role
+  clusterRoleBindings:
+    annotations: {}
+    labels: {}
+    bindings:
+    # - apiGroup: rbac.authorization.k8s.io
+    #   kind: ClusterRole
+    #   name: my-cluster-role
 
 # To configure the affinity. This same configuration is used for each service.
 affinity:


### PR DESCRIPTION
Allows providing Roles and ClusterRoles that the structural service account should be bound to. This is to support customers that bring their own RBAC.