### PR TITLE
Add options for getting db credentials and Docker image pull secret from Kubernetes secrets

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -497,7 +497,9 @@ caller (which is ideally the root value of the chart).
 
 {{- define "tonic.imagePullSecret.default" -}}
 {{- $top := first . }}
-{{- if $top.Values.dockerConfigAuth }}
+{{- if $top.Values.dockerConfigSecretRef }}
+- name: {{ $top.Values.dockerConfigSecretRef }}
+{{- else if $top.Values.dockerConfigAuth }}
 - name: {{ include "tonic.imagePullSecret.defaultName" $top }}
 {{- end }}
 {{- end }}

--- a/templates/_helpers.web-server.yaml
+++ b/templates/_helpers.web-server.yaml
@@ -18,6 +18,7 @@
     {{- toYaml . | nindent 12 }}
 {{- end }}
 {{- end }}
+{{- if $top.Values.tonicdb.dbConfigFromValues }}
 - name: TONIC_DB_DATABASE
   value: {{ $top.Values.tonicdb.dbName }}
 - name: TONIC_DB_USERNAME
@@ -33,6 +34,7 @@
   value: {{ $top.Values.tonicdb.sslMode }}
 - name: TONIC_DB_HOST
   value: {{ $top.Values.tonicdb.host }}
+{{- end }}
   {{- if $top.Values.tonicStatisticsSeed }}
 - name: TONIC_STATISTICS_SEED
   value: {{quote $top.Values.tonicStatisticsSeed }}

--- a/templates/tests/test-connection.yaml
+++ b/templates/tests/test-connection.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enableTests }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -13,3 +14,4 @@ spec:
       command: ['wget']
       args: ['tonic-web-server:443']
   restartPolicy: Never
+{{- end }}

--- a/templates/tonic-notifications-deployment.yaml
+++ b/templates/tonic-notifications-deployment.yaml
@@ -64,6 +64,7 @@ spec:
             {{- toYaml . | nindent 12 }}
         {{- end }}
         {{- end }}
+        {{- if .Values.tonicdb.dbConfigFromValues }}
         - name: TONIC_DB_DATABASE
           value: {{ .Values.tonicdb.dbName }}
         - name: TONIC_DB_USERNAME
@@ -79,6 +80,7 @@ spec:
             secretKeyRef:
               name: tonic-db-password
               key: password
+        {{- end }}
         {{- $smtp := .Values.tonicSmtpConfig }}
         {{- if $smtp.tonicUrl }}
         - name: TONIC_URL

--- a/templates/tonic-worker-deployment.yaml
+++ b/templates/tonic-worker-deployment.yaml
@@ -101,6 +101,7 @@ spec:
             - name: CONTAINERIZATION_IMAGE_REPOSITORY
               value: {{ .Values.containerization.datapacker.imageRepo }}
             {{- end }}
+            {{- if .Values.tonicdb.dbConfigFromValues }}
             - name: TONIC_DB_DATABASE
               value: {{ .Values.tonicdb.dbName }}
             - name: TONIC_DB_USERNAME
@@ -116,6 +117,7 @@ spec:
               value: {{ .Values.tonicdb.sslMode }}
             - name: TONIC_DB_HOST
               value: {{ .Values.tonicdb.host }}
+            {{- end }}  
               {{- if .Values.tonicStatisticsSeed }}
             - name: TONIC_STATISTICS_SEED
               value: {{quote .Values.tonicStatisticsSeed }}

--- a/values.sample.yaml
+++ b/values.sample.yaml
@@ -17,6 +17,21 @@ readOnlyRootFilesystem: false
 
 # tonicdb is the postgres database that will hold information about your workspace.
 tonicdb:
+  # dbConfigFromValues field specifies where the database properties are retrieved from.
+  # If it is set to true, the database properties are retrieved from values.yaml file and
+  # added to env section of the deployments as environment variables (named TONIC_DB_XXX).
+  # If it is set to false, the environment variables will not be added to the deployments.
+  # In that case, the environment variables can be put into a Kubernetes secret or config map and
+  # can be referenced with envFrom.
+  # tonicai:
+  #    web_server:
+  #      envFrom:
+  #        - secretRef:
+  #            name: tonic-structural
+  #        - configMapRef:
+  #            name: tonic-structural
+  dbConfigFromValues: true
+
   host: <db-host>
   port: 5432
   dbName: tonic
@@ -34,6 +49,8 @@ numberOfWorkers: 1
 
 # This value will be provided to you by Tonic and will allow you to authenticate against our private docker repository.
 dockerConfigAuth: <docker-config-auth>
+# Alternatively, you can put it in a secret and reference it below.
+dockerConfigSecretRef: 
 
 # Service account for tonic
 serviceAccount:
@@ -301,3 +318,6 @@ containerization:
 
 # Your license should be configured by an admin within the Tonic UI. It can optionally be set here if there is no admin.
 # tonicLicense: <license-key>
+
+# Enable or disable test pods
+enableTests: true


### PR DESCRIPTION
This MR adds the following options to make Helm chart more configurable for different use cases.

dbConfigFromValues: it allows db configuration to be retrieved from Kubernetes secrets or configmaps via envFrom option. Without this field, TONIC_DB_XXX environment variables added to env section of the deployments with the values from values.yaml file and they override the environment variables added with envFrom.

dockerConfigSecretRef: it allows Docker image pull secret to be specified in a Kubernetes secret as a reference instead of specifying the credential in values.yaml directly.

enableTests: allows disabling adding test pods.
