### PR TITLE
TN-56596 : Allow notifications ports to be configured from values.yaml

### DIFF
--- a/templates/tonic-notifications-deployment.yaml
+++ b/templates/tonic-notifications-deployment.yaml
@@ -4,7 +4,7 @@
   $notifications.resources
   (dict "limits" (dict "memory" "1Gi") "requests" (dict "memory" "512Mi" "ephemeral-storage" "1Gi"))
 -}}
-{{- $rawPorts := include "tonic.ports" (list $ (dict "http" 7000 "https" 7001 "httpsOnly" false)) }}
+{{- $rawPorts := include "tonic.ports" (list $ $notifications.ports (dict "http" 7000 "https" 7001 "httpsOnly" false)) }}
 {{- $ports := fromYaml $rawPorts }}
 {{- $podLabels := merge (dict "app" "tonic-notifications") ($notifications.pod).labels }}
 {{- $podAnnotations := coalesce ($notifications.pod).annotations (dict) }}

--- a/templates/tonic-notifications-service.yaml
+++ b/templates/tonic-notifications-service.yaml
@@ -1,3 +1,5 @@
+{{- $notifications := .Values.tonicai.notifications }}
+{{- $ports := fromYaml (include "tonic.ports" (list $ $notifications.ports (dict "http" 7000 "https" 7001 "httpsOnly" false))) }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -9,11 +11,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   ports:
-  - name: "7000"
-    port: 7000
+  {{- if not $ports.httpsOnly }}
+  - name: {{ $ports.http | quote }}
+    port: {{ $ports.http }}
     targetPort: http
-  - name: "7001"
-    port: 7001
+  {{- end }}
+  - name: {{ $ports.https | quote }}
+    port: {{ $ports.https }}
     targetPort: https
   selector:
     app: tonic-notifications

--- a/values.sample.yaml
+++ b/values.sample.yaml
@@ -177,6 +177,10 @@ tonicai:
     # deployStrategy: RollingUpdate
     env: {}
     envRaw: {}
+    ports:
+      httpsOnly: false
+      http: 7000
+      https: 7001
     resources:
       requests:
         memory: "512Mi"


### PR DESCRIPTION
## Summary
- Passes `$notifications.ports` through to the `tonic.ports` helper in the notifications deployment and service templates
- The service now uses `$ports.http`/`$ports.https` variables and respects `httpsOnly` (consistent with the worker service)
- Adds a `ports` block to the notifications section in `values.sample.yaml` documenting the defaults (http: 7000, https: 7001)

Defaults are unchanged — if `ports` is not set, `tonic.ports` falls back to the original hardcoded values.

Closes TN-56596

## Test plan
- [ ] Helm template renders correctly with no `ports` set (ports remain 7000/7001)
- [ ] Helm template renders correctly with custom `http` and `https` ports set
- [ ] Helm template renders correctly with `httpsOnly: true` (HTTP port omitted from service)

🤖 Generated with [Claude Code](https://claude.com/claude-code)