### PR TITLE
Set scheduling attributes per deployment

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -325,12 +325,15 @@ caller (which is ideally the root value of the chart).
 {{- $selectors := dict }}
 {{- if ($top.Values).nodeSelector }}
 {{- $selectors = merge $selectors $top.Values.nodeSelector }}
+{{- end }}
 {{- if (gt (len .) 1) }}
+{{- $these := index . 1 }}
+{{- if $these }}
 {{- $selectors = merge $selectors (index . 1) }}
+{{- end }}
 {{- end }}
 {{- if $selectors }}
 {{- $selectors | toYaml }}
-{{- end }}
 {{- end }}
 {{- end }}
 
@@ -339,12 +342,15 @@ caller (which is ideally the root value of the chart).
 {{- $affinity := dict }}
 {{- if ($top.Values).affinity }}
 {{- $affinity = merge $affinity $top.Values.affinity }}
+{{- end }}
 {{- if (gt (len .) 1) }}
-{{- $affinity = merge $affinity (index . 1) }}
+{{- $these := index . 1 }}
+{{- if $these }}
+{{- $affinity = merge $affinity $these }}
+{{- end }}
 {{- end }}
 {{- if $affinity }}
 {{- $affinity | toYaml }}
-{{- end }}
 {{- end }}
 {{- end }}
 

--- a/templates/tonic-notifications-deployment.yaml
+++ b/templates/tonic-notifications-deployment.yaml
@@ -36,11 +36,11 @@ spec:
         tonic.ai/metrics: "structural-notifications"
     spec:
       nodeSelector:
-        {{- include "tonic.nodeSelectors" (list $) | nindent 8 }}
+        {{- include "tonic.nodeSelectors" (list $ $notifications.nodeSelector) | nindent 8 }}
       affinity:
-        {{- include "tonic.affinity" (list $) | nindent 8 }}
+        {{- include "tonic.affinity" (list $ $notifications.affinity) | nindent 8 }}
       tolerations:
-        {{- include "tonic.tolerations" (list $) | nindent 8 }}
+        {{- include "tonic.tolerations" (list $ $notifications.tolerations) | nindent 8 }}
       securityContext:
         {{- if .Values.useUnprivilegedContainers }}
         seccompProfile:

--- a/templates/tonic-web-server-deployment.yaml
+++ b/templates/tonic-web-server-deployment.yaml
@@ -38,11 +38,11 @@ spec:
         tonic.ai/metrics: "structural-web-server"
     spec:
       nodeSelector:
-        {{- include "tonic.nodeSelectors" (list $) | nindent 8 }}
+        {{- include "tonic.nodeSelectors" (list $ $server.nodeSelector) | nindent 8 }}
       affinity:
-        {{- include "tonic.affinity" (list $) | nindent 8 }}
+        {{- include "tonic.affinity" (list $ $server.affinity) | nindent 8 }}
       tolerations:
-        {{- include "tonic.tolerations" (list $) | nindent 8 }}
+        {{- include "tonic.tolerations" (list $ $server.tolerations) | nindent 8 }}
       securityContext:
         {{- include "tonic.web.pod.securityContext" (list $) | nindent 8 }}
       initContainers:

--- a/templates/tonic-worker-deployment.yaml
+++ b/templates/tonic-worker-deployment.yaml
@@ -49,11 +49,11 @@ spec:
         tonic.ai/metrics: "structural-worker"
     spec:
       nodeSelector:
-        {{- include "tonic.nodeSelectors" (list $) | nindent 8 }}
+        {{- include "tonic.nodeSelectors" (list $ $worker.nodeSelector) | nindent 8 }}
       affinity:
-        {{- include "tonic.affinity" (list $) | nindent 8 }}
+        {{- include "tonic.affinity" (list $ $worker.affinity) | nindent 8 }}
       tolerations:
-        {{- include "tonic.tolerations" (list $) | nindent 8 }}
+        {{- include "tonic.tolerations" (list $ $worker.tolerations) | nindent 8 }}
       securityContext:
         {{- if .Values.useUnprivilegedContainers }}
         seccompProfile:


### PR DESCRIPTION
Allows defining scheduling attributes such as nodeSelector, tolerations and nodeAffinity per deployment.